### PR TITLE
Update get_stop_predictions URL (#1)

### DIFF
--- a/metlink/metlink.py
+++ b/metlink/metlink.py
@@ -222,7 +222,7 @@ class Metlink():
         '''
         if stop_id:
             response = self.__get_metlink_data(
-                '?stop_id=' + const.STOP_PREDICTIONS_URL + str(stop_id))
+                 const.STOP_PREDICTIONS_URL + '?stop_id=' + str(stop_id))
             stop_predictions = []
             for stop in response['departures']:
                 prediction = {

--- a/tests/test_metlink.py
+++ b/tests/test_metlink.py
@@ -53,3 +53,10 @@ def test_service_alerts():
     metlink_obj = Metlink(get_api_key())
     service_alerts = metlink_obj.get_service_alerts()
     assert service_alerts is not None
+
+
+def test_stop_predictions():
+    """ Tests the get_stop_predictions method """
+    metlink_obj = Metlink(get_api_key())
+    stop_predictions = metlink_obj.get_stop_predictions(stop_id=5000)
+    assert stop_predictions is not None


### PR DESCRIPTION
* Update get_stop_predictions URL

previous url was constructed in reverse so `?stop_id=` appeared before `https://api.metlink...`

* Add test of stop predictions